### PR TITLE
refactor: SDK initialization 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
-# 1.1.1+2
+# 1.2.0+0
+ - Breaking change: Made initialization of sdk asynchronous.
+ - Added run method to Evaluate experiment. 
+ - Removed SDKBuilder. 
+
+# 1.1.1
 
 - Fixed `features` value parsing. 
 
-# 1.1.0+2
+# 1.1.0
 
 - Migrated to dart 2.17.2.
 - fix: Data parsing problem.

--- a/README.md
+++ b/README.md
@@ -41,13 +41,14 @@ Integration is super easy:
 Now you can start/stop tests, adjust coverage and variation weights, and apply a winning variation to 100% of traffic, all within the Growth Book App without deploying code changes to your site.
 
 ```dart
-final GrowthBookSDK sdkInstance = GBSDKBuilderApp(
+final GrowthBookSDK sdkInstance = await GBSDKBuilderApp(
   apiKey: "<API_KEY>",
   attributes: {
     /// Specify attributes.
   },
   growthBookTrackingCallBack: (gbExperiment, gbExperimentResult) {},
   hostURL: '<GrowthBook_URL>',
+  apiKey: '<YOUR API KEY>'
 ).initialize();
 
 ```
@@ -55,20 +56,17 @@ final GrowthBookSDK sdkInstance = GBSDKBuilderApp(
 There are additional properties which can be setup at the time of initialization
 
 ```dart
-    final GrowthBookSDK newSdkInstance = GBSDKBuilderApp(
+    final GrowthBookSDK newSdkInstance =await GBSDKBuilderApp(
     apiKey: "<API_KEY>",
     attributes: {
      /// Specify user attributes.
     },
+    client: NetworkClient(), // Provide network dispatcher.
     growthBookTrackingCallBack: (gbExperiment, gbExperimentResult) {},
     hostURL: '<GrowthBook_URL>',
-).setNetworkDispatcher(
-  // set network dispatcher.
-)
-   .setForcedVariations({})
-   . // Set forced variations
-   setQAMode(true)// Set qamode
-   .initialize();
+    forcedVariations: {} // Optional provide force variation.
+    qaMode: true, // Set qamode
+).initialize();
 
 ```
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -54,18 +54,14 @@ class _HomeState extends State<Home> with SingleTickerProviderStateMixin {
     initializeSDK();
   }
 
-  void initializeSDK() {
-    gb = GBSDKBuilderApp(
-            apiKey: kReleaseMode ? '<PROD_KEY>' : '<DEV_KEY>',
-            hostURL: '<HOST_URL>',
-            attributes: userAttr,
-            growthBookTrackingCallBack: (experiment, experimentResult) {
-              /// Track feature.
-            })
-        .initialize()
-      ..afterFetch = () {
-        setState(() {});
-      };
+  void initializeSDK() async {
+    gb = await GBSDKBuilderApp(
+      apiKey: kReleaseMode ? '<PROD_KEY>' : '<DEV_KEY>',
+      hostURL: '<HOST_URL>',
+      attributes: userAttr,
+      growthBookTrackingCallBack: (exp, rst) {},
+    ).initialize();
+    setState(() {});
   }
 
   Widget _getRightWidget() {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -87,7 +87,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.1.1+2"
+    version: "1.2.0+0"
   http_parser:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.9.0"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,14 +21,21 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.0"
+  charcode:
+    dependency: transitive
+    description:
+      name: charcode
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
@@ -56,7 +63,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -108,28 +115,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.11"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.1"
   quiver:
     dependency: transitive
     description:
@@ -148,7 +155,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -169,21 +176,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.9"
   tuple:
     dependency: transitive
     description:

--- a/lib/src/Evaluator/experiment_evaluator.dart
+++ b/lib/src/Evaluator/experiment_evaluator.dart
@@ -13,7 +13,7 @@ class GBExperimentEvaluator {
     ///  (not in experiment, variationId 0)
     ///
     /// If context.enabled is false, return immediately (not in experiment, variationId 0)
-    if (experiment.variations!.length < 2 || !context.enabled!) {
+    if (experiment.variations.length < 2 || !context.enabled!) {
       return _getExperimentResult(experiment: experiment, gbContext: context);
     }
 
@@ -44,9 +44,9 @@ class GBExperimentEvaluator {
     /// If experiment.namespace is set, check if hash value is included in the
     ///  range and if not, return immediately (not in experiment, variationId 0)
     if (experiment.namespace != null) {
-      var namespace = GBUtils().getGBNameSpace(experiment.namespace!);
+      var namespace = const GBUtils().getGBNameSpace(experiment.namespace!);
       if (experiment.namespace != null &&
-          !GBUtils().inNamespace(attributeValue, namespace!)) {
+          !const GBUtils().inNamespace(attributeValue, namespace!)) {
         return _getExperimentResult(experiment: experiment, gbContext: context);
       }
     }
@@ -66,7 +66,7 @@ class GBExperimentEvaluator {
     if (weights == null) {
       // Default weights to an even split between all variations
       experiment.weights =
-          GBUtils().getEqualWeights(experiment.variations?.length ?? 1);
+          const GBUtils().getEqualWeights(experiment.variations.length);
     }
 
     final coverage = experiment.coverage ?? 1.0;
@@ -74,8 +74,8 @@ class GBExperimentEvaluator {
 
     /// Calculate bucket ranges for the variations
     /// Convert weights/coverage to ranges
-    final List<GBBucketRange> bucketRange = GBUtils().getBucketRanges(
-        experiment.variations!.length,
+    final List<GBBucketRange> bucketRange = const GBUtils().getBucketRanges(
+        experiment.variations.length,
         coverage,
         experiment.weights != null
             ? experiment.weights!
@@ -83,10 +83,10 @@ class GBExperimentEvaluator {
                 .toList()
             : []);
 
-    final hash = GBUtils().hash(attributeValue + experiment.key);
+    final hash = const GBUtils().hash(attributeValue + experiment.key);
     late final int assigned;
     if (hash != null) {
-      assigned = GBUtils().chooseVariation(hash, bucketRange);
+      assigned = const GBUtils().chooseVariation(hash, bucketRange);
     }
     // If not assigned a variation (assigned === -1), return immediately (not in experiment, variationId 0)
     if (assigned == -1) {
@@ -130,21 +130,17 @@ class GBExperimentEvaluator {
     var targetVariationIndex = variationIndex;
 
     // Check whether variationIndex lies within bounds of variations size
-    if (experiment.variations != null) {
-      if (targetVariationIndex < 0 ||
-          targetVariationIndex >= experiment.variations!.length) {
-        // Set to 0
-        targetVariationIndex = 0;
-      }
+    if (targetVariationIndex < 0 ||
+        targetVariationIndex >= experiment.variations.length) {
+      // Set to 0
+      targetVariationIndex = 0;
     }
 
     dynamic targetValue = 0;
 
     // check whether variations are non empty - then only query array against index
-    if (experiment.variations != null) {
-      if (experiment.variations!.isNotEmpty) {
-        targetValue = experiment.variations![targetVariationIndex];
-      }
+    if (experiment.variations.isNotEmpty) {
+      targetValue = experiment.variations[targetVariationIndex];
     }
 
     // Hash Attribute - used for Experiment Calculations

--- a/lib/src/Model/experiment.dart
+++ b/lib/src/Model/experiment.dart
@@ -8,7 +8,7 @@ part 'experiment.g.dart';
 class GBExperiment {
   GBExperiment({
     this.key,
-    this.variations,
+    this.variations = const [],
     this.namespace,
     this.condition,
     this.hashAttribute,
@@ -22,7 +22,7 @@ class GBExperiment {
   String? key;
 
   /// The different variations to choose between
-  List? variations = [];
+  List variations = [];
 
   /// A tuple that contains the namespace identifier, plus a range of coverage for the experiment
   List? namespace;

--- a/lib/src/Model/experiment.g.dart
+++ b/lib/src/Model/experiment.g.dart
@@ -8,7 +8,7 @@ part of 'experiment.dart';
 
 GBExperiment _$GBExperimentFromJson(Map<String, dynamic> json) => GBExperiment(
       key: json['key'] as String?,
-      variations: json['variations'] as List<dynamic>?,
+      variations: json['variations'] as List<dynamic>? ?? const [],
       namespace: json['namespace'] as List<dynamic>?,
       condition: json['condition'],
       hashAttribute: json['hashAttribute'] as String?,

--- a/lib/src/Utils/gb_utils.dart
+++ b/lib/src/Utils/gb_utils.dart
@@ -25,6 +25,8 @@ class FNV {
 /// - chooseVariation
 /// - getGBNameSpace
 class GBUtils {
+  const GBUtils();
+
   /// Hashes a string to a float between 0 and 1
   /// fnv32a returns an integer, so we convert that to a float using a modulus:
 

--- a/lib/src/growth_book_sdk.dart
+++ b/lib/src/growth_book_sdk.dart
@@ -18,11 +18,11 @@ class GBSDKBuilderApp {
 
   final String apiKey;
   final String hostURL;
-  final TrackingCallBack growthBookTrackingCallBack;
-  final bool qaMode;
   final bool enable;
-  final Map<String, int> forcedVariations;
+  final bool qaMode;
   final Map<String, dynamic>? attributes;
+  final Map<String, int> forcedVariations;
+  final TrackingCallBack growthBookTrackingCallBack;
   final BaseClient? client;
 
   Future<GrowthBookSDK> initialize() async {
@@ -30,8 +30,8 @@ class GBSDKBuilderApp {
       apiKey: apiKey,
       hostURL: hostURL,
       enabled: enable,
-      attributes: attributes,
       qaMode: qaMode,
+      attributes: attributes,
       forcedVariation: forcedVariations,
       trackingCallBack: growthBookTrackingCallBack,
     );
@@ -61,7 +61,7 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
 
   final BaseClient _baseClient;
 
-  /// Context - Holding the complete data regarding features & attributes etc.
+  /// The complete data regarding features & attributes etc.
   GBContext get context => _context;
 
   /// Retrieved features.

--- a/lib/src/growth_book_sdk.dart
+++ b/lib/src/growth_book_sdk.dart
@@ -4,56 +4,28 @@ import 'package:growthbook_sdk_flutter/growthbook_sdk_flutter.dart';
 
 typedef VoidCallback = void Function();
 
-abstract class SDKBuilder {
-  SDKBuilder({
-    required this.apiKey,
+class GBSDKBuilderApp {
+  GBSDKBuilderApp({
     required this.hostURL,
-    this.attributes = const <String, dynamic>{},
+    required this.apiKey,
     required this.growthBookTrackingCallBack,
-  })  : qaMode = false,
-        forcedVariations = <String, int>{},
-        enable = true;
+    this.attributes = const <String, dynamic>{},
+    this.qaMode = false,
+    this.enable = true,
+    this.forcedVariations = const <String, int>{},
+    this.client,
+  });
 
   final String apiKey;
   final String hostURL;
-  Map<String, dynamic>? attributes;
   final TrackingCallBack growthBookTrackingCallBack;
+  final bool qaMode;
+  final bool enable;
+  final Map<String, int> forcedVariations;
+  final Map<String, dynamic>? attributes;
+  final BaseClient? client;
 
-  bool qaMode;
-
-  bool enable;
-
-  Map<String, int> forcedVariations;
-
-  ///  Set Forced Variations - Default Empty
-  SDKBuilder setForcedVariations(Map<String, int> forcedVariations) {
-    this.forcedVariations = forcedVariations;
-    return this;
-  }
-
-  /// Set Enabled - Default Disabled - If Enabled - then experiments will be disabled
-  SDKBuilder setQAMode(bool value) {
-    qaMode = value;
-    return this;
-  }
-
-  GrowthBookSDK initialize();
-}
-
-class GBSDKBuilderApp extends SDKBuilder {
-  GBSDKBuilderApp({
-    required super.apiKey,
-    required super.hostURL,
-    super.attributes = const <String, dynamic>{},
-    required super.growthBookTrackingCallBack,
-  }) {
-    customLogger('GrowthBook initialized successfully.');
-  }
-
-  BaseClient? _client;
-
-  @override
-  GrowthBookSDK initialize() {
+  Future<GrowthBookSDK> initialize() async {
     final gbContext = GBContext(
       apiKey: apiKey,
       hostURL: hostURL,
@@ -63,75 +35,66 @@ class GBSDKBuilderApp extends SDKBuilder {
       forcedVariation: forcedVariations,
       trackingCallBack: growthBookTrackingCallBack,
     );
-    return GrowthBookSDK(context: gbContext, client: _client);
-  }
-
-  ///   Set Network Client - Network Client for Making API Calls
-  SDKBuilder setNetworkDispatcher(BaseClient client) {
-    _client = client;
-    return this;
+    final gb = GrowthBookSDK._(
+      context: gbContext,
+      client: client,
+    );
+    await gb.refresh();
+    return gb;
   }
 }
 
 /// The main export of the libraries is a simple GrowthBook wrapper class that
 /// takes a Context object in the constructor.
 /// It exposes two main methods: feature and run.
-/// It also includes stream of [StateHelper] which can be utilized in case
-/// sdk is not loaded yet and we want to show some in place.
 class GrowthBookSDK extends FeaturesFlowDelegate {
-  GrowthBookSDK(
-      {required GBContext context,
-      GBFeatures? features,
-      BaseClient? client,
-      VoidCallback? afterFetch})
+  GrowthBookSDK._(
+      {required GBContext context, GBFeatures? features, BaseClient? client})
       : _context = context,
-        _sdkStreamController = StreamController<StateHelper>(),
         _baseClient = client ?? DioClient() {
     if (features != null) {
       _context.features = features;
     }
-    _sdkStreamController.sink.add(StateHelper.loading);
-    refresh();
   }
-  final StreamController<StateHelper> _sdkStreamController;
 
-  VoidCallback? afterFetch;
-
-  ///
   final GBContext _context;
 
+  final BaseClient _baseClient;
+
+  /// Context - Holding the complete data regarding features & attributes etc.
   GBContext get context => _context;
 
+  /// Retrieved features.
   GBFeatures get features => _context.features;
-
-  Stream<StateHelper> get stream =>
-      _sdkStreamController.stream.asBroadcastStream();
-
-  final BaseClient _baseClient;
 
   @override
   void featuresFetchedSuccessfully(GBFeatures gbFeatures) {
     _context.features = gbFeatures;
-    if (afterFetch != null) {
-      afterFetch!.call();
-    }
-    _sdkStreamController.sink.add(StateHelper.fetched);
   }
 
   Future<void> refresh() async {
     final featureViewModel = FeatureViewModel(
       delegate: this,
       source: FeatureDataSource(
-          client: _baseClient,
-          context: _context,
-          onError: (e, s) {
-            _sdkStreamController.sink.add(StateHelper.error);
-          }),
+        client: _baseClient,
+        context: _context,
+        onError: (e, s) {},
+      ),
     );
     await featureViewModel.fetchFeature();
   }
 
   GBFeatureResult feature(String id) {
     return GBFeatureEvaluator().evaluateFeature(_context, id);
+  }
+
+  GBExperimentResult run(GBExperiment experiment) {
+    return GBExperimentEvaluator()
+        .evaluateExperiment(context: context, experiment: experiment);
+  }
+
+  /// Replaces the Map of user attributes that are used to assign variations
+  void setAttributes(Map<String, dynamic> attributes) {
+    context.attributes = attributes;
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.9.0"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -98,7 +98,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.0"
+  charcode:
+    dependency: transitive
+    description:
+      name: charcode
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -112,7 +119,7 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.0"
   code_builder:
     dependency: transitive
     description:
@@ -161,7 +168,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.0"
   file:
     dependency: transitive
     description:
@@ -276,21 +283,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.11"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.7.0"
   mime:
     dependency: transitive
     description:
@@ -311,7 +318,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.1"
   pool:
     dependency: transitive
     description:
@@ -379,7 +386,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -407,21 +414,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.9"
   timing:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: growthbook_sdk_flutter
 description: An open-source feature flagging and experimentation platform that makes it simple to alter features and execute A/B testing.
-version: 1.1.1+2
-homepage: https://github.com/alippo-com/GrowthBook-SDK-Flutter
+version: 1.2.0+0
+repository: https://github.com/alippo-com/GrowthBook-SDK-Flutter
 
 environment:
   sdk: ">=2.17.2 <3.0.0"

--- a/test/mocks/network_mock.dart
+++ b/test/mocks/network_mock.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:growthbook_sdk_flutter/growthbook_sdk_flutter.dart';
 
 class MockNetworkClient implements BaseClient {
+  const MockNetworkClient();
   @override
   consumeGetRequest(String path, OnSuccess onSuccess, OnError onError) {
     final pseudoResponse = jsonDecode(MockResponse.successResponse);


### PR DESCRIPTION
## Description:
1. To make the initialization of the SDK asynchronous, to avoid empty features after calling initialize method on `GBSDKBuilderApp`. 
2. To add `run` functionality inside GBSDKBuilderApp to run an experiment.  
## Tasks:

- [x] Removed `SDKBuilder` from SDK.
- [x] Make SDK initialization method async.  
- [x] Update initialization test cases
- [x] Add run method to evaluate experiment inside SDK
- [x] Update the changelog. 
- [x] Update documentation on both repos. 

## Notes: 
This will close #28 