### PR TITLE
Allow features to be seeded to prevent possible LateInitializationError 

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -45,7 +45,8 @@ class _HomeState extends State<Home> with SingleTickerProviderStateMixin {
   /// Initialization of controllers.
   late TabController _tabController;
   final userAttr = {"id": Platform.isIOS ? "foo" : "foo_bar"};
-  late final GrowthBookSDK gb;
+  GrowthBookSDK? gb;
+
   @override
   void initState() {
     super.initState();
@@ -60,12 +61,13 @@ class _HomeState extends State<Home> with SingleTickerProviderStateMixin {
       hostURL: '<HOST_URL>',
       attributes: userAttr,
       growthBookTrackingCallBack: (exp, rst) {},
+      features: {'some-feature': GBFeature(defaultValue: true)},
     ).initialize();
     setState(() {});
   }
 
   Widget _getRightWidget() {
-    if (gb.feature('random').on!) {
+    if (gb != null && gb!.feature('random').on!) {
       return TabBar(
         isScrollable: true,
         tabs: tabs,
@@ -105,8 +107,9 @@ class _HomeState extends State<Home> with SingleTickerProviderStateMixin {
                         Text(tabNames[i]),
                         ElevatedButton(
                           onPressed: () {
-                            //
-                            gb.features.forEach((key, value) {});
+                            if (gb != null) {
+                              gb!.features.forEach((key, value) {});
+                            }
                           },
                           child: const Text('Press'),
                         )

--- a/lib/src/Features/feature_data_source.dart
+++ b/lib/src/Features/feature_data_source.dart
@@ -11,15 +11,19 @@ class FeatureDataSource {
   final BaseClient client;
   final OnError onError;
 
-  Future<FeaturedDataModel> fetchFeatures() async {
+  FeaturedDataModel model = FeaturedDataModel(features: {});
+  Map<String, dynamic> data = {};
+
+  Future<FeaturedDataModel?> fetchFeatures() async {
     final api = context.hostURL! + Constant.featurePath + context.apiKey!;
-    await client.consumeGetRequest(api, onSuccess, onError);
+    try {
+      await client.consumeGetRequest(api, onSuccess, onError);
+    } catch (e) {
+      return null;
+    }
     setUpModel();
     return model;
   }
-
-  late FeaturedDataModel model;
-  late Map<String, dynamic> data;
 
   /// Assign response to local variable [data]
   void onSuccess(response) {
@@ -28,6 +32,8 @@ class FeatureDataSource {
 
   /// Initialize [model] from the [data]
   void setUpModel() {
-    model = FeaturedDataModel.fromJson(data);
+    if (data.isNotEmpty) {
+      model = FeaturedDataModel.fromJson(data);
+    }
   }
 }

--- a/lib/src/Features/features_view_model.dart
+++ b/lib/src/Features/features_view_model.dart
@@ -11,7 +11,11 @@ class FeatureViewModel {
 
   Future<void> fetchFeature() async {
     try {
-      final model = await source.fetchFeatures();
+      FeaturedDataModel? model = await source.fetchFeatures();
+      if (model == null) {
+        customLogger('FeatureVieModel did NOT fetched features successfully.');
+        return;
+      }
       delegate.featuresFetchedSuccessfully(model.features);
       customLogger('FeatureVieModel have fetched features successfully.');
     } catch (e) {

--- a/lib/src/Model/context.dart
+++ b/lib/src/Model/context.dart
@@ -10,6 +10,7 @@ class GBContext {
     this.forcedVariation,
     this.qaMode,
     this.trackingCallBack,
+    this.features = const <String, GBFeature>{},
   });
 
   /// Registered API key for GrowthBook SDK.
@@ -35,5 +36,5 @@ class GBContext {
 
   /// Keys are unique identifiers for the features and the values are Feature objects.
   /// Feature definitions - To be pulled from API / Cache
-  GBFeatures features = <String, GBFeature>{};
+  GBFeatures features;
 }

--- a/lib/src/growth_book_sdk.dart
+++ b/lib/src/growth_book_sdk.dart
@@ -14,6 +14,7 @@ class GBSDKBuilderApp {
     this.enable = true,
     this.forcedVariations = const <String, int>{},
     this.client,
+    this.features = const <String, GBFeature>{},
   });
 
   final String apiKey;
@@ -24,6 +25,7 @@ class GBSDKBuilderApp {
   final Map<String, int> forcedVariations;
   final TrackingCallBack growthBookTrackingCallBack;
   final BaseClient? client;
+  final Map<String, GBFeature> features;
 
   Future<GrowthBookSDK> initialize() async {
     final gbContext = GBContext(
@@ -34,6 +36,7 @@ class GBSDKBuilderApp {
       attributes: attributes,
       forcedVariation: forcedVariations,
       trackingCallBack: growthBookTrackingCallBack,
+      features: features,
     );
     final gb = GrowthBookSDK._(
       context: gbContext,
@@ -78,7 +81,9 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
       source: FeatureDataSource(
         client: _baseClient,
         context: _context,
-        onError: (e, s) {},
+        onError: (e, s) {
+          throw Exception(e);
+        },
       ),
     );
     await featureViewModel.fetchFeature();

--- a/test/common_test/sdk_builder_test.dart
+++ b/test/common_test/sdk_builder_test.dart
@@ -66,5 +66,23 @@ void main() {
       final result = sdk.run(GBExperiment(key: "fwrfewrfe"));
       expect(result.variationID, 0);
     });
+
+    test('- with failed network client', () async {
+      late GrowthBookSDK sdk;
+
+      sdk = await GBSDKBuilderApp(
+        apiKey: testApiKey,
+        hostURL: testHostURL,
+        attributes: attr,
+        client: const MockNetworkClient(error: true),
+        growthBookTrackingCallBack: (exp, result) {},
+        features: {'some-feature': GBFeature(defaultValue: true)},
+      ).initialize();
+      final featureValue = sdk.feature('some-feature');
+      expect(featureValue.value, true);
+
+      final result = sdk.run(GBExperiment(key: "some-feature"));
+      expect(result.variationID, 0);
+    });
   });
 }

--- a/test/mocks/network_mock.dart
+++ b/test/mocks/network_mock.dart
@@ -1,14 +1,30 @@
 import 'dart:convert';
 
+import 'package:dio/dio.dart';
 import 'package:growthbook_sdk_flutter/growthbook_sdk_flutter.dart';
 
 class MockNetworkClient implements BaseClient {
-  const MockNetworkClient();
+  final bool error;
+
+  const MockNetworkClient({this.error = false});
+
   @override
   consumeGetRequest(String path, OnSuccess onSuccess, OnError onError) {
     final pseudoResponse = jsonDecode(MockResponse.successResponse);
-    onSuccess(pseudoResponse);
-    return pseudoResponse;
+    if (error) {
+      onError(
+        DioError(
+          type: DioErrorType.other,
+          requestOptions: RequestOptions(path: '', baseUrl: ''),
+          response: null,
+          error:
+              'SocketException: Failed host lookup: \'cdn.growthbook.io\' (OS Error: nodename nor servname provided, or not known, errno = 8)',
+        ),
+        StackTrace.fromString('DioError from test'),
+      );
+    } else {
+      onSuccess(pseudoResponse);
+    }
   }
 }
 


### PR DESCRIPTION
It appears that some recent changes have removed the ability to `seed` features prior to initializing `GBSDKBuilderApp`. The issue I discovered is that if initialization fails then we end up not being able to set the `seeds` at all and depending on the project setup, this could cause issues in the app behavior. In this PR, my goal is to allow the features `seeds` to be passed into the `GBSDKBuilderApp` object constructor so we can seed the features and then attempt to get the remote features from GrowthBook.

Previously, in `FeatureDataSource.fetchFeatures`, if `client.consumeGetRequest` fails `data` is never initialized, which is then used to initialize model. Both `data` and `model` are marked as late so when they are accessed at this point we get a `LateInitializationError`. To prevent this from happening, I have changed those from `late` properties to initialized with empty `Maps`.

In `FeatureDataSource`, `client.consumeGetRequest` is now wrapped in a `try/catch` block and I added a `throw` to `onError`. So if `client.consumeGetRequest` fails, we can catch it and `return null` from `FeatureDataSource.fetchFeatures` and skip the `setUpModel()` call. 
In `setUpModel()`, we check if data is empty, if it is, skip the `.fromJson` call.

In `FeaturesViewModel.fetchFeatures`, `source.fetchFeatures()` is used to initialize `model`. 
I have change `model` to be optional so if `FeatureDataSource.fetchFeatures` returns `null` we can skip the call to `delegate.featuresFetchedSuccessfully()` which would override our seeds with an empty `Map`.

In `GBContext`’s constructor I have added the `features` param so we are able to seed our features at the beginning of the initialization process.

To make sure these changes continue working in the future, I have added a test `with failed network client` that simulates a failed networks request and expects the seeded feature. To help facilitate this test I also updated the MockNetworkClient constructor to take an bool `error` when we want to mock an error. The property defaults to false when nothing is passed so other uses do not need to be updated. I attempted to recreate the error details as close as possible to real details we’d get when there is no network connection.

I also took the liberty of updating the example project:
The `gb` property is now optional, so if initialization fails we can check if it is null and avoid another LateInitializationError.
I added the `features` param to the GBSDKBuilderApp constructor to show that it is possible to pass in initial values/seeds to set features while we wait for initialization to finish.
Finally we check if `gb` is null before attempting to build the `_getRightWidget()`, otherwise we would see a flash of red on the device screen if the example app is launched when there is no internet connection.
