### PR TITLE
Fix LateInitialization in FeatureDataSource

### DIFF
--- a/lib/src/Features/feature_data_source.dart
+++ b/lib/src/Features/feature_data_source.dart
@@ -5,29 +5,13 @@ abstract class FeaturesFlowDelegate {
 }
 
 class FeatureDataSource {
-  FeatureDataSource(
-      {required this.context, required this.client, required this.onError});
+  FeatureDataSource({required this.context, required this.client});
   final GBContext context;
   final BaseClient client;
-  final OnError onError;
 
   Future<FeaturedDataModel> fetchFeatures() async {
     final api = context.hostURL! + Constant.featurePath + context.apiKey!;
-    await client.consumeGetRequest(api, onSuccess, onError);
-    setUpModel();
-    return model;
-  }
-
-  late FeaturedDataModel model;
-  late Map<String, dynamic> data;
-
-  /// Assign response to local variable [data]
-  void onSuccess(response) {
-    data = response;
-  }
-
-  /// Initialize [model] from the [data]
-  void setUpModel() {
-    model = FeaturedDataModel.fromJson(data);
+    final data = await client.consumeGetRequest(api);
+    return FeaturedDataModel.fromJson(data);
   }
 }

--- a/lib/src/Network/network.dart
+++ b/lib/src/Network/network.dart
@@ -1,11 +1,8 @@
 import 'package:dio/dio.dart';
 
-typedef OnSuccess = void Function(Map<String, dynamic> onSuccess);
-typedef OnError = void Function(Object error, StackTrace stackTrace);
-
 abstract class BaseClient {
   const BaseClient();
-  consumeGetRequest(String path, OnSuccess onSuccess, OnError onError);
+  Future<Map<String, dynamic>> consumeGetRequest(String path);
 }
 
 class DioClient extends BaseClient {
@@ -14,12 +11,8 @@ class DioClient extends BaseClient {
   final Dio _dio;
 
   @override
-  consumeGetRequest(String path, OnSuccess onSuccess, OnError onError) async {
-    try {
-      final data = await _dio.get(path);
-      onSuccess(data.data);
-    } catch (e, s) {
-      onError(e, s);
-    }
+  Future<Map<String, dynamic>> consumeGetRequest(String path) async {
+    final data = await _dio.get(path);
+    return data.data;
   }
 }

--- a/lib/src/growth_book_sdk.dart
+++ b/lib/src/growth_book_sdk.dart
@@ -78,10 +78,17 @@ class GrowthBookSDK extends FeaturesFlowDelegate {
       source: FeatureDataSource(
         client: _baseClient,
         context: _context,
-        onError: (e, s) {},
       ),
     );
-    await featureViewModel.fetchFeature();
+    try {
+      await featureViewModel.fetchFeature();
+    } catch (e) {
+      // NOTE: I added this try/catch to swallow errors here to maintain the
+      // existing behavior where FeatureDataSource(onError) used to swallow
+      // these errors. If we were to remove this try/catch block then the
+      // exception would propagate up through the Future giving the consumer
+      // the option to ignore it or handle it.
+    }
   }
 
   GBFeatureResult feature(String id) {

--- a/test/common_test/features_view_model_test.dart
+++ b/test/common_test/features_view_model_test.dart
@@ -27,7 +27,7 @@ void main() {
       featureViewModel = FeatureViewModel(
         delegate: dataSourceMock,
         source: FeatureDataSource(
-            client: MockNetworkClient(), context: context, onError: (e, s) {}),
+            client: const MockNetworkClient(), context: context),
       );
     });
     test('success feature-view model.', () async {

--- a/test/mocks/network_mock.dart
+++ b/test/mocks/network_mock.dart
@@ -5,9 +5,8 @@ import 'package:growthbook_sdk_flutter/growthbook_sdk_flutter.dart';
 class MockNetworkClient implements BaseClient {
   const MockNetworkClient();
   @override
-  consumeGetRequest(String path, OnSuccess onSuccess, OnError onError) {
+  Future<Map<String, dynamic>> consumeGetRequest(String path) async {
     final pseudoResponse = jsonDecode(MockResponse.successResponse);
-    onSuccess(pseudoResponse);
     return pseudoResponse;
   }
 }

--- a/test/src/Features/feature_data_source_test.dart
+++ b/test/src/Features/feature_data_source_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:growthbook_sdk_flutter/growthbook_sdk_flutter.dart';
+
+class _MockError extends Error {}
+
+class _MockFailingNetworkClient implements BaseClient {
+  const _MockFailingNetworkClient();
+  @override
+  Future<Map<String, dynamic>> consumeGetRequest(String path) {
+    throw _MockError();
+  }
+}
+
+void main() {
+  group('FeatureDataSource', () {
+    group('featureFeatures', () {
+      test('propogates thrown errors from the client', () async {
+        const testApiKey = '<SOME KEY>';
+        const attr = <String, String>{};
+        const testHostURL = '<HOST URL>';
+        final context = GBContext(
+          apiKey: testApiKey,
+          hostURL: testHostURL,
+          attributes: attr,
+          enabled: true,
+          forcedVariation: {},
+          qaMode: false,
+          trackingCallBack: (_, __) {},
+        );
+
+        bool onErrorHappened = false;
+
+        final featureDataSource = FeatureDataSource(
+            context: context, client: const _MockFailingNetworkClient());
+
+        try {
+          await featureDataSource.fetchFeatures();
+        } on _MockError catch (_) {
+          onErrorHappened = true;
+        }
+
+        expect(onErrorHappened, true);
+      });
+    });
+  });
+}


### PR DESCRIPTION
Prior to this patch when FeatureDataSource would fail due to a client failure it would incorrectly result in a LateInitialization exception. This was because FeatureDataSource was written assuming the client was Future<> based but the client was actually Callback based. Having these two different async approaches is not beneficial and is what enables this LateInitialization issue to even be possible.

To resolve this issue I changed the abstract BaseClient interface to use the newer Future<> style async rather than the older style Callback approach.

I then proceeded to update the FeatureDataSource to properly use the new Future<> based client properly and also modified it to eliminate it's needless propagation of the onError callback. I then went through and made sure that all the uses of FeatureDataSource were properly updated. I then made sure to even wrap the usage of FeatureDataSource is in a swallowing try/catch to maintain the existing external behavior. We made decide to change this. But figured it best to not change external behavior of the API as that would be a breaking change.

In my opinion changing the behavior to NOT swallow errors would be a better long term approach IMHO. It would enable users to, for one, be aware of the errors that are happening. And two, be able to explicitly handle or ignore the errors. But, to expedite getting this change in I will leave this for a future patch where more time and discussion can be had around it. As it would be a breaking change.

[changelog]
fixed: LateInitialization exception on client failures in FeatureDataSource